### PR TITLE
allow building on centos7 (boost 1.53)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ endif()
 # Find Boost (with Boost Python)
 #------------------------------------
 set(Boost_PYTHON_VERSION "python3" CACHE STRING "libboost_<Boost_PYTHON_VERSION><*>.<ext>")
-find_package( Boost 1.58 COMPONENTS ${Boost_PYTHON_VERSION} REQUIRED )
+find_package( Boost 1.53 COMPONENTS ${Boost_PYTHON_VERSION} REQUIRED )
 if( NOT Boost_FOUND ) 
   message(STATUS "Could not find Boost Python installation!")
   message(STATUS "Check 1:")

--- a/src/c_boost/xyce/boost_adm_parser_common.h
+++ b/src/c_boost/xyce/boost_adm_parser_common.h
@@ -23,7 +23,7 @@
 
 #if !defined(ADM_BOOST_COMMON)
 #define ADM_BOOST_COMMON
-
+#define FUSION_MAX_VECTOR_SIZE 15
 #include <boost/config/warning_disable.hpp>
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/phoenix_core.hpp>


### PR DESCRIPTION
Hello,
To build on RedHat/CentOS 7, it would require to rebuild the requested boost version 1.58.
This tiny patch makes it to build with rh7 boost 1.53.
Thanks for the tool!