### PR TITLE
 Fixes segfault when there is a line with an inline comment followed by two continuation lines.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 
 # ignore build dir
 build/
+cmake-build-debug/

--- a/src/c_boost/xyce/parser_interface.hpp
+++ b/src/c_boost/xyce/parser_interface.hpp
@@ -145,6 +145,7 @@ struct NetlistLineReader {
         bool foundEnd = false;
         std::string origCommandLine = "";
         std::string tmpOrigCommandLine = stripInlineCommentString(parsedLine.sourceLine, g);
+        boost::trim_right(tmpOrigCommandLine);
         std::string tmpCommandLine;
         std::vector<std::string> results;
 


### PR DESCRIPTION
The segfault occurs because the originalLine string now contains a space
that the currentRtnLine does not. This means that the split won't work
since the original string does not meaning results is a vector of length
1 who contains only the original string.

This solves https://groups.google.com/g/xyce-users/c/HG7nLX4FYTw