### PR TITLE
Fix missing sstream include

### DIFF
--- a/src/c_boost/expr/ast_common.hpp
+++ b/src/c_boost/expr/ast_common.hpp
@@ -44,6 +44,7 @@ const double M_PI = boost::math::constants::pi<double>();
 #include <random>
 #include <string>
 #include <unordered_map>
+#include <sstream>
 
 #include "boost_expr_parser_common.h"
 


### PR DESCRIPTION
src/c_boost/expr/ast_common.hpp makes use of std::istringstream, but does not include \<sstream\>.

Some boost header must have silently pulled in sstream, but as of boost 1.84 that no longer happens.  Trying to build XDM with boost 1.84 fails as a result.

This commit makes ast_common.hpp include \<sstream\> itself, and that fixes the problem.

Tagging @Karlsefni2012 @gjtempl @TBird2001 directly so they see this sooner.

Closes GH-11 

(hint, if you use `git format-patch master..fixsstream` on this repo or simply access https://github.com/Xyce/XDM/pull/12.patch , you can get a patch file you can insert into the official repo with `git am`)